### PR TITLE
'createsuperuser' command

### DIFF
--- a/hub/settings.py
+++ b/hub/settings.py
@@ -32,13 +32,13 @@ ALLOWED_HOSTS = []
 # Application definition
 
 INSTALLED_APPS = [
+    'hub_app',
     'django.contrib.admin',
     'django.contrib.auth',
     'django.contrib.contenttypes',
     'django.contrib.sessions',
     'django.contrib.messages',
     'django.contrib.staticfiles',
-    'hub_app',
 ]
 
 MIDDLEWARE = [

--- a/hub_app/management/commands/createsuperuser.py
+++ b/hub_app/management/commands/createsuperuser.py
@@ -18,6 +18,20 @@ from django.utils.translation import gettext_lazy as _
 from hub_app.models import HubUser
 
 
+def get_input():  # pragma: no cover
+    """
+    Get Input Abstraction
+    """
+    return input()
+
+
+def get_masked_input(prompt: str):  # pragma: no cover
+    """
+    Get Password Abstraction
+    """
+    return getpass(prompt=prompt)
+
+
 class Command(BaseCommand):
     """
     Create a 'hub_app' superuser
@@ -60,10 +74,10 @@ class Command(BaseCommand):
         :raises CommandError: When something is wrong with the input
         """
         if masked:
-            data = getpass(prompt='{}: '.format(field))
+            data = get_masked_input(prompt='{}: '.format(field))
         else:
             self.stdout.write('{}: '.format(field), ending='')
-            data = input()
+            data = get_input()
         if data is None:
             raise CommandError(_('"%(field)s" is required') % {'field': field})
         data = data.strip()

--- a/hub_app/management/commands/createsuperuser.py
+++ b/hub_app/management/commands/createsuperuser.py
@@ -1,0 +1,150 @@
+"""
+Override the Django 'createsuperuser' command
+
+hub_app superusers need a TOTP secret
+"""
+import argparse
+import binascii
+from base64 import b32decode
+from getpass import getpass
+
+from django.contrib.auth.password_validation import validate_password
+from django.contrib.auth.validators import ASCIIUsernameValidator
+from django.core.exceptions import ValidationError
+from django.core.management import BaseCommand, CommandError
+from django.db import transaction
+from django.utils.translation import gettext_lazy as _
+
+from hub_app.models import HubUser
+
+
+class Command(BaseCommand):
+    """
+    Create a 'hub_app' superuser
+    """
+
+    requires_migrations_checks = True
+    requires_system_checks = True
+
+    help = _('Create a superuser for the hub_app')
+
+    def add_arguments(self, parser: argparse.ArgumentParser):
+        """
+        Add the four fields to fill as parameters
+        """
+        parser.add_argument(
+            '-u', '--username',
+            nargs='?', required=False, type=str,
+            help=_('Username for the new superuser; must be unique')
+        )
+        parser.add_argument(
+            '-p', '--password',
+            nargs='?', required=False, type=str,
+            help=_('Password for the new superuser')
+        )
+        parser.add_argument(
+            '-s', '--secret',
+            nargs='?', required=False, type=str,
+            help=_('BASE32 encoded shared secret for TOTP')
+        )
+
+    def get_from_user_input(self, field, masked: bool = False) -> str:
+        """
+        Get User Input for a field
+
+        :param field: Field Name
+        :param masked: Shall the input be masked?
+        :rtype: str
+        :returns: The User Input
+
+        :raises CommandError: When something is wrong with the input
+        """
+        if masked:
+            data = getpass(prompt='{}: '.format(field))
+        else:
+            self.stdout.write('{}: '.format(field), ending='')
+            data = input()
+        if data is None:
+            raise CommandError(_('"%(field)s" is required') % {'field': field})
+        data = data.strip()
+        if len(data) == 0:
+            raise CommandError(_('"%(field)s" is required') % {'field': field})
+        return data
+
+    def database_operation(self, username: str, password: str, secret: bytes):
+        """
+        Create the superuser in the database
+
+        :param str username: The Username
+        :param str password: The Password
+        :param bytes secret: The Secret (binary format)
+
+        :raises CommandError: When something is wrong
+        """
+        try:
+            HubUser.objects.get(username=username)
+            raise CommandError(_('The user "%(username)s" already exists.') % {'username': username})
+        except HubUser.DoesNotExist:
+            with transaction.atomic():
+                tx_id = transaction.savepoint()
+                try:
+                    superuser = HubUser.objects.create_superuser(
+                        username=username,
+                        password=password,
+                    )  # type: HubUser
+                    superuser.set_totp_secret(secret)
+                    superuser.save()
+                    self.stdout.write(self.style.SUCCESS(_('Superuser "%(username)s" created successfully') % {
+                        'username': username
+                    }))
+                    transaction.savepoint_commit(tx_id)
+                except ValueError as ex:
+                    transaction.savepoint_rollback(tx_id)
+                    raise CommandError(_('Unable to create user "%(username)s: %(message)s"') % {
+                        'username': username,
+                        'message': str(ex)
+                    })
+
+    def validate_input_and_create_superuser(self, username: str, password: str, secret: str):
+        """
+        Check all fields, then create a superuser
+
+        :param str username: The Username
+        :param str password: The Password
+        :param str secret: The Secret (BASE32 format)
+
+        :raises CommandError: When something is wrong
+        """
+        try:
+            ASCIIUsernameValidator()(username)
+        except ValidationError as ex:
+            raise CommandError(_('Username "%(username)s" is invalid: %(message)s') % {
+                'username': username, 'message': ex.message
+            })
+        try:
+            validate_password(password)
+        except ValidationError as ex:
+            raise CommandError('{}: {}'.format(
+                _('The password is invalid'),
+                ' '.join(ex.messages)
+            ))
+        try:
+            secret_bin = b32decode(secret)
+        except binascii.Error as ex:
+            raise CommandError(_('Invalid TOTP Secret: %(message)s') % {
+                'message': str(ex)
+            })
+        self.database_operation(username, password, secret_bin)
+
+    def handle(self, *args, **options):
+        username = options.get('username', None)
+        password = options.get('password', None)
+        secret = options.get('secret', None)
+
+        if username is None:
+            username = self.get_from_user_input(_('Username'))
+        if password is None:
+            password = self.get_from_user_input(_('Password'), True)
+        if secret is None:
+            secret = self.get_from_user_input(_('Secret (BASE32 format)'))
+        self.validate_input_and_create_superuser(username.lower(), password, secret)

--- a/hub_app/management/commands/createsuperuser.py
+++ b/hub_app/management/commands/createsuperuser.py
@@ -22,7 +22,7 @@ def get_input():  # pragma: no cover
     """
     Get Input Abstraction
     """
-    return input()
+    return input()  # nosec
 
 
 def get_masked_input(prompt: str):  # pragma: no cover

--- a/hub_app/tests/test_command_createsuperuser.py
+++ b/hub_app/tests/test_command_createsuperuser.py
@@ -88,7 +88,7 @@ class CreateSuperUserFromCommandLineTest(TestCase):
                     secret=secret,
                     stdout=out
                 )
-                self.assertEquals(1, HubUser.objects.count())
+                self.assertEqual(1, HubUser.objects.count())
 
     def test_duplicate(self):
         """

--- a/hub_app/tests/test_command_createsuperuser.py
+++ b/hub_app/tests/test_command_createsuperuser.py
@@ -1,0 +1,280 @@
+"""
+Test Suite for the 'createsuperuser' command
+"""
+from io import StringIO
+from unittest.mock import patch
+
+from django.core.management import call_command, CommandError
+from django.test import TestCase
+
+from hub_app.management.commands import createsuperuser
+from hub_app.models import HubUser
+
+
+class CreateSuperUserFromCommandLineTest(TestCase):
+    """
+    Test the creation of a SuperUser from the Command Line
+    """
+
+    @classmethod
+    def setUpTestData(cls):
+        cls.existing_superuser = HubUser.objects.create_user(  # nosec
+            username='test_user_that_exists',
+            password='0nLiF4outS0meTe$ting'
+        )
+
+    def test_good_case(self):
+        """
+        Test positive case
+        """
+        with StringIO() as out:
+            call_command(  # nosec
+                createsuperuser.Command(),
+                username='test@test.org',
+                password='12Test34$56oO.',
+                secret='SUPERSECRETSUPERSUPERSECRETSUPERSUPERSECRETSUPERSUPERSECRETSUPER',
+                stdout=out
+            )
+            self.assertRegex(
+                out.getvalue(),
+                r'(Superuser\s"test@test\.org"\screated\ssuccessfully).{0,10}$'
+            )
+        obj = HubUser.objects.get(username='test@test.org')  # type: HubUser
+        self.assertTrue(obj.is_active)
+        self.assertTrue(obj.is_superuser)
+        self.assertTrue(obj.is_staff)
+
+    def test_bad_cases(self):
+        """
+        Test bad cases
+        """
+        test_items = (
+            # case, user, pass, secret
+            ('Empty Username',
+             '', 'W3ryG0oDPA5sWOrd', 'SUPERSECRETSUPERSUPERSECRETSUPERSUPERSECRETSUPERSUPERSECRETSUPER'),
+            ('Empty Password',
+             'test1', '', 'SUPERSECRETSUPERSUPERSECRETSUPERSUPERSECRETSUPERSUPERSECRETSUPER'),
+            ('Empty Secret',
+             'test2', 'W3ryG0oDPA5sWOrd', ''),
+            ('Empty Username and empty Password',
+             '', '', 'SUPERSECRETSUPERSUPERSECRETSUPERSUPERSECRETSUPERSUPERSECRETSUPER'),
+            ('Empty Username, empty Password and empty Secret',
+             '', '', ''),
+            ('Too short secret',
+             'test3', 'W3ryG0oDPA5sWOrd', 'SUPERSECRETSUPER'),
+            ('Invalid secret',
+             'test4', 'W3ryG0oDPA5sWOrd', '1234SUPERSECRETSUPER'),
+            ('Password too short',
+             'test5', 'W3rWOrd', 'SUPERSECRETSUPERSUPERSECRETSUPERSUPERSECRETSUPERSUPERSECRETSUPER'),
+            ('Password only numbers',
+             'test6', '1234123499', 'SUPERSECRETSUPERSUPERSECRETSUPERSUPERSECRETSUPERSUPERSECRETSUPER'),
+            ('Password too common',
+             'test7', 'testtest', 'SUPERSECRETSUPERSUPERSECRETSUPERSUPERSECRETSUPERSUPERSECRETSUPER'),
+            ('None Username',
+             None, 'W3ryG0oDPA5sWOrd', 'SUPERSECRETSUPERSUPERSECRETSUPERSUPERSECRETSUPERSUPERSECRETSUPER'),
+            ('None Password',
+             'test8', None, 'SUPERSECRETSUPERSUPERSECRETSUPERSUPERSECRETSUPERSUPERSECRETSUPER'),
+            ('None Secret',
+             'test9', 'W3ryG0oDPA5sWOrd', None),
+        )
+        for test_case, username, password, secret in test_items:
+            with self.subTest(msg='Testing case "{}"'.format(test_case)), StringIO() as out:
+                self.assertRaises(  # nosec
+                    CommandError,
+                    call_command,
+                    createsuperuser.Command(),
+                    username=username,
+                    password=password,
+                    secret=secret,
+                    stdout=out
+                )
+                self.assertEquals(1, HubUser.objects.count())
+
+    def test_duplicate(self):
+        """
+        Try to create a duplicate
+        """
+        with StringIO() as out:
+            self.assertRaisesRegex(  # nosec
+                CommandError,
+                r'(The\suser\s"test_user_that_exists"\salready\sexists\.).{0,10}$',
+                call_command,
+                createsuperuser.Command(),
+                username='test_user_that_exists',
+                password='12Test34$56oO.',
+                secret='SUPERSECRETSUPERSUPERSECRETSUPERSUPERSECRETSUPERSUPERSECRETSUPER',
+                stdout=out
+            )
+
+
+class CreateSuperUserFromUserInputTest(TestCase):
+    """
+    Create a superuser with user input
+    """
+
+    @patch('hub_app.management.commands.createsuperuser.get_input', return_value='test-user1')
+    def test_good_case_username(self, _):
+        """
+        Test the good case with username
+        """
+        with StringIO() as out:
+            call_command(  # nosec
+                createsuperuser.Command(),
+                password='12Test34$56oO.',
+                secret='SUPERSECRETSUPERSUPERSECRETSUPERSUPERSECRETSUPERSUPERSECRETSUPER',
+                stdout=out
+            )
+            self.assertRegex(
+                out.getvalue(),
+                r'(Superuser\s"test-user1"\screated\ssuccessfully).{0,10}$'
+            )
+        obj = HubUser.objects.get(username='test-user1')  # type: HubUser
+        self.assertIsNotNone(obj)
+
+    @patch('hub_app.management.commands.createsuperuser.get_input',
+           return_value='SUPERSECRETSUPERSUPERSECRETSUPERSUPERSECRETSUPERSUPERSECRETSUPER')
+    def test_good_case_secret(self, _):
+        """
+        Test the good case with secret
+        """
+        with StringIO() as out:
+            call_command(  # nosec
+                createsuperuser.Command(),
+                username='test-user2',
+                password='12Test34$56oO.',
+                stdout=out
+            )
+            self.assertRegex(
+                out.getvalue(),
+                r'(Superuser\s"test-user2"\screated\ssuccessfully).{0,10}$'
+            )
+            obj = HubUser.objects.get(username='test-user2')  # type: HubUser
+            self.assertIsNotNone(obj)
+
+    @patch('hub_app.management.commands.createsuperuser.get_masked_input', return_value='12Test34$56oO.')
+    def test_good_case_password(self, _):
+        """
+        Test the good case with password
+        """
+        with StringIO() as out:
+            call_command(  # nosec
+                createsuperuser.Command(),
+                username='test-user3',
+                secret='SUPERSECRETSUPERSUPERSECRETSUPERSUPERSECRETSUPERSUPERSECRETSUPER',
+                stdout=out
+            )
+            self.assertRegex(
+                out.getvalue(),
+                r'(Superuser\s"test-user3"\screated\ssuccessfully).{0,10}$'
+            )
+        obj = HubUser.objects.get(username='test-user3')  # type: HubUser
+        self.assertIsNotNone(obj)
+
+    @patch('hub_app.management.commands.createsuperuser.get_masked_input', return_value='12Test34$56oO.')
+    @patch('hub_app.management.commands.createsuperuser.get_input', return_value='test-user4')
+    def test_good_case_username_and_password(self, *_):
+        """
+        Test the good case with username and password
+        """
+        with StringIO() as out:
+            call_command(  # nosec
+                createsuperuser.Command(),
+                secret='SUPERSECRETSUPERSUPERSECRETSUPERSUPERSECRETSUPERSUPERSECRETSUPER',
+                stdout=out
+            )
+            self.assertRegex(
+                out.getvalue(),
+                r'(Superuser\s"test-user4"\screated\ssuccessfully).{0,10}$'
+            )
+        obj = HubUser.objects.get(username='test-user4')  # type: HubUser
+        self.assertIsNotNone(obj)
+
+    @patch('hub_app.management.commands.createsuperuser.get_input', return_value='')
+    def test_bad_case_empty_username(self, _):
+        """
+        Test bad case with an empty username
+        """
+        with StringIO() as out:
+            self.assertRaises(  # nosec
+                CommandError,
+                call_command,
+                createsuperuser.Command(),
+                password='12Test34$56oO.',
+                secret='SUPERSECRETSUPERSUPERSECRETSUPERSUPERSECRETSUPERSUPERSECRETSUPER',
+                stdout=out
+            )
+
+    @patch('hub_app.management.commands.createsuperuser.get_input', return_value='')
+    def test_bad_case_empty_secret(self, _):
+        """
+        Test bad case with an empty secret
+        """
+        with StringIO() as out:
+            self.assertRaises(  # nosec
+                CommandError,
+                call_command,
+                createsuperuser.Command(),
+                username='test-user7',
+                password='12Test34$56oO.',
+                stdout=out
+            )
+
+    @patch('hub_app.management.commands.createsuperuser.get_masked_input', return_value='')
+    def test_bad_case_empty_password(self, _):
+        """
+        Test bad case with an empty password
+        """
+        with StringIO() as out:
+            self.assertRaises(  # nosec
+                CommandError,
+                call_command,
+                createsuperuser.Command(),
+                username='test-user8',
+                secret='SUPERSECRETSUPERSUPERSECRETSUPERSUPERSECRETSUPERSUPERSECRETSUPER',
+                stdout=out
+            )
+
+    @patch('hub_app.management.commands.createsuperuser.get_input', return_value=None)
+    def test_bad_case_none_username(self, _):
+        """
+        Test bad case with an none username
+        """
+        with StringIO() as out:
+            self.assertRaises(  # nosec
+                CommandError,
+                call_command,
+                createsuperuser.Command(),
+                password='12Test34$56oO.',
+                secret='SUPERSECRETSUPERSUPERSECRETSUPERSUPERSECRETSUPERSUPERSECRETSUPER',
+                stdout=out
+            )
+
+    @patch('hub_app.management.commands.createsuperuser.get_input', return_value=None)
+    def test_bad_case_none_secret(self, _):
+        """
+        Test bad case with an none secret
+        """
+        with StringIO() as out:
+            self.assertRaises(  # nosec
+                CommandError,
+                call_command,
+                createsuperuser.Command(),
+                username='test-user7',
+                password='12Test34$56oO.',
+                stdout=out
+            )
+
+    @patch('hub_app.management.commands.createsuperuser.get_masked_input', return_value=None)
+    def test_bad_case_none_password(self, _):
+        """
+        Test bad case with an none password
+        """
+        with StringIO() as out:
+            self.assertRaises(  # nosec
+                CommandError,
+                call_command,
+                createsuperuser.Command(),
+                username='test-user8',
+                secret='SUPERSECRETSUPERSUPERSECRETSUPERSUPERSECRETSUPERSUPERSECRETSUPER',
+                stdout=out
+            )

--- a/hub_app/tests/test_command_createsuperuser.py
+++ b/hub_app/tests/test_command_createsuperuser.py
@@ -70,12 +70,6 @@ class CreateSuperUserFromCommandLineTest(TestCase):
              'test6', '1234123499', 'SUPERSECRETSUPERSUPERSECRETSUPERSUPERSECRETSUPERSUPERSECRETSUPER'),
             ('Password too common',
              'test7', 'testtest', 'SUPERSECRETSUPERSUPERSECRETSUPERSUPERSECRETSUPERSUPERSECRETSUPER'),
-            ('None Username',
-             None, 'W3ryG0oDPA5sWOrd', 'SUPERSECRETSUPERSUPERSECRETSUPERSUPERSECRETSUPERSUPERSECRETSUPER'),
-            ('None Password',
-             'test8', None, 'SUPERSECRETSUPERSUPERSECRETSUPERSUPERSECRETSUPERSUPERSECRETSUPER'),
-            ('None Secret',
-             'test9', 'W3ryG0oDPA5sWOrd', None),
         )
         for test_case, username, password, secret in test_items:
             with self.subTest(msg='Testing case "{}"'.format(test_case)), StringIO() as out:


### PR DESCRIPTION
- Override for the Django default management command 'createsuperuser'
- Incorporates the TOTP secret that is required for logging in
- Fully functional via command line arguments and user input