### PR TITLE
Publishing JSON Schema

### DIFF
--- a/.pylint.ini
+++ b/.pylint.ini
@@ -7,7 +7,7 @@ extension-pkg-whitelist=
 
 # Add files or directories to the blacklist. They should be base names, not
 # paths.
-ignore=CVS,.git,venv,virtualenv,hub_app/migrations
+ignore=CVS,.git,venv,virtualenv,hub_app/migrations,hub_json_schema/migrations
 
 # Add files or directories matching the regex patterns to the blacklist. The
 # regex matches against base names, not paths.

--- a/.travis.yml
+++ b/.travis.yml
@@ -32,7 +32,7 @@ script:
   - coverage run --rcfile=.coveragerc.ini manage.py test --settings=hub.ci_settings
   - coverage report --rcfile=.coveragerc.ini
   - flake8 --statistics --config=.flake8.ini .
-  - pylint --rcfile=.pylint.ini hub hub_app
+  - pylint --rcfile=.pylint.ini hub hub_app hub_json_schema
   - bandit -r ./
 
 after_script:

--- a/hub/settings.py
+++ b/hub/settings.py
@@ -38,6 +38,7 @@ ALLOWED_HOSTS = []
 
 INSTALLED_APPS = [
     'hub_app',
+    'hub_json_schema',
     'django.contrib.admin',
     'django.contrib.auth',
     'django.contrib.contenttypes',
@@ -248,3 +249,7 @@ EMAIL_USE_LOCALTIME = False
 ADMINS = (
     ('Test Admin', 'test-admin@passiopeia.github.io'),
 )
+
+
+# JSON Schema Settings
+JSON_SCHEMA_BASE = 'http://localhost:8000/schema/'

--- a/hub/urls.py
+++ b/hub/urls.py
@@ -23,5 +23,6 @@ urlpatterns = [  # pylint: disable=invalid-name
     path('admin/', admin_site.urls, name='admin'),
     path('client-configuration/i18n/', include('django.conf.urls.i18n')),
     path('hub/', include(('hub_app.urls', 'hub_app'), namespace='ha')),
+    path('schema/', include(('hub_json_schema.urls', 'hub_json_schema'), namespace='json')),
     url('^$', RedirectView.as_view(url=reverse_lazy('ha:home'), permanent=False), name='index'),
 ]

--- a/hub_json_schema/__init__.py
+++ b/hub_json_schema/__init__.py
@@ -1,0 +1,5 @@
+"""
+Setting the Default App Config
+"""
+
+default_app_config = 'hub_json_schema.apps.HubJsonSchemaConfig'  # pylint: disable=invalid-name

--- a/hub_json_schema/apps.py
+++ b/hub_json_schema/apps.py
@@ -1,0 +1,14 @@
+"""
+Django Application config
+"""
+from django.apps import AppConfig
+
+from django.utils.translation import gettext_lazy as _
+
+
+class HubJsonSchemaConfig(AppConfig):
+    """
+    App Config for the 'hub_json_schema'
+    """
+    name = 'hub_json_schema'
+    verbose_name = _('* Passiopeia Hub JSON Schema')

--- a/hub_json_schema/registry.py
+++ b/hub_json_schema/registry.py
@@ -1,0 +1,44 @@
+"""
+Registry for JSON Schema
+"""
+from hub_json_schema.schema import PUBLISHED
+
+
+class Singleton(type):
+    """
+    Define a singleton Meta Class
+    """
+
+    _instances = {}
+
+    def __call__(cls, *args, **kwargs):
+        if cls not in cls._instances:
+            cls._instances[cls] = super(Singleton, cls).__call__(*args, **kwargs)
+        return cls._instances[cls]
+
+
+class Registry(metaclass=Singleton):  # pylint: disable=too-few-public-methods
+    """
+    Define the singleton Registry
+    """
+
+    def __init__(self):
+        """
+        Initialize from the published classes
+        """
+        self.__registry = {}
+        for schema in PUBLISHED:
+            version = str(schema.schema_version)
+            name = schema.schema_name
+            if name not in self.__registry.keys():
+                self.__registry[name] = {}
+            if version in self.__registry[name]:  # pragma: no cover  # Only a safeguard during JSON Schema development
+                raise ValueError('Duplicated JSON Schema Version: Name="{}", Version="{}"'.format(name, version))
+            self.__registry[name][version] = schema.schema_definition
+
+    @property
+    def schemas(self):
+        """
+        Access to the Schema
+        """
+        return self.__registry

--- a/hub_json_schema/schema/__init__.py
+++ b/hub_json_schema/schema/__init__.py
@@ -1,0 +1,9 @@
+"""
+Which Schema Classes are published?
+"""
+from hub_json_schema.schema.types import UsernameTypeV1, PasswordTypeV1, OtpTypeV1, CredentialsTypeV1
+
+
+PUBLISHED = (
+    UsernameTypeV1, PasswordTypeV1, OtpTypeV1, CredentialsTypeV1,
+)

--- a/hub_json_schema/schema/base/schema.py
+++ b/hub_json_schema/schema/base/schema.py
@@ -1,0 +1,13 @@
+"""
+Schema Base Classes
+"""
+
+
+class JsonSchema:  # pylint: disable=too-few-public-methods
+    """
+    Basic Schema Definition
+    """
+
+    schema_name = ''
+    schema_version = 0
+    schema_definition = {}

--- a/hub_json_schema/schema/types.py
+++ b/hub_json_schema/schema/types.py
@@ -1,0 +1,99 @@
+"""
+Types with the Hub Application
+"""
+from django.conf import settings
+
+from hub_json_schema.schema.base.schema import JsonSchema
+
+
+class UsernameTypeV1(JsonSchema):  # pylint: disable=too-few-public-methods
+    """
+    Type def for username
+    """
+
+    schema_name = 'type-username'
+    schema_version = 1
+
+    schema_definition = {
+        "id": '{}{}-v{}'.format(settings.JSON_SCHEMA_BASE, schema_name, schema_version),
+        "definitions": {
+            "username": {
+                "type": "string",
+                "minLength": 3,
+                "maxLength": 150,
+                "pattern": r'^[\w.@+-]{3,150}$',
+            }
+        }
+    }
+
+
+class PasswordTypeV1(JsonSchema):  # pylint: disable=too-few-public-methods
+    """
+    Type def for password
+    """
+
+    schema_name = 'type-password'
+    schema_version = 1
+
+    schema_definition = {
+        "id": '{}{}-v{}'.format(settings.JSON_SCHEMA_BASE, schema_name, schema_version),
+        "definitions": {
+            "password": {
+                "type": "string",
+                "minLength": 8,
+                "maxLength": 1024,
+            }
+        }
+    }
+
+
+class OtpTypeV1(JsonSchema):  # pylint: disable=too-few-public-methods
+    """
+    Type def for OTP
+    """
+
+    schema_name = 'type-otp'
+    schema_version = 1
+
+    schema_definition = {
+        "id": '{}{}-v{}'.format(settings.JSON_SCHEMA_BASE, schema_name, schema_version),
+        "definitions": {
+            "username": {
+                "type": "string",
+                "minLength": 6,
+                "maxLength": 6,
+                "pattern": r'^[0-9]{6,6}$',
+            }
+        }
+    }
+
+
+class CredentialsTypeV1(JsonSchema):  # pylint: disable=too-few-public-methods
+    """
+    Type def for Credentials
+    """
+
+    schema_name = 'type-credentials'
+    schema_version = 1
+
+    schema_definition = {
+        "id": '{}{}-v{}'.format(settings.JSON_SCHEMA_BASE, schema_name, schema_version),
+        "definitions": {
+            "credentials": {
+                "type": "object",
+                "required": ["username", "password", "otp"],
+                "additionalProperties": False,
+                "properties": {
+                    "username": {
+                        "$ref": '{}#/definitions/username'.format(UsernameTypeV1.schema_definition.get('id'))
+                    },
+                    "password": {
+                        "$ref": '{}#/definitions/password'.format(PasswordTypeV1.schema_definition.get('id'))
+                    },
+                    "otp": {
+                        "$ref": '{}#/definitions/otp'.format(OtpTypeV1.schema_definition.get('id'))
+                    }
+                }
+            }
+        }
+    }

--- a/hub_json_schema/templates/hub_json_schema/list-view.html
+++ b/hub_json_schema/templates/hub_json_schema/list-view.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>Passiopeia Hub JSON Schema</title>
+</head>
+<body>
+    <h1>Available JSON Schemas</h1>
+    <dl>
+        {% for schema_name, schema_versions in schemas.items %}
+            <dt>{{ schema_name }}</dt>
+            {% for schema_version, schema_definition in schema_versions.items %}
+                <dd><a href="{% url 'json:schema' schema_name schema_version %}">v{{ schema_version }}</a></dd>
+            {% endfor %}
+        {% endfor %}
+    </dl>
+</body>
+</html>

--- a/hub_json_schema/tests.py
+++ b/hub_json_schema/tests.py
@@ -1,0 +1,65 @@
+"""
+Tests for the JSON Schema App
+"""
+from bs4 import BeautifulSoup
+from django.conf import settings
+from django.test import SimpleTestCase, TestCase
+
+from hub_json_schema.schema import PUBLISHED
+from hub_json_schema.schema.base.schema import JsonSchema
+
+
+class PublishedSchemaTest(SimpleTestCase):
+    """
+    Test all published schemas
+    """
+
+    def test_schemas(self):
+        """
+        Test the schemas
+        """
+        for schema in PUBLISHED:
+            with self.subTest(msg='Testing schema "{}"'.format(schema)):
+                self.assertIsNotNone(schema)
+                self.assertIn(JsonSchema, schema.__bases__)
+                self.assertIsNotNone(getattr(schema, 'schema_name'))
+                self.assertIsNotNone(getattr(schema, 'schema_version'))
+                self.assertIsNotNone(getattr(schema, 'schema_definition'))
+                self.assertGreater(int(schema.schema_version), 0)
+                self.assertIsInstance(schema.schema_name, str)
+                self.assertIsInstance(schema.schema_definition, dict)
+                self.assertTrue(schema.schema_definition.get('id').startswith(settings.JSON_SCHEMA_BASE))
+
+
+class SchemaViewTest(TestCase):
+    """
+    Test Schema Views
+    """
+
+    def test_all_schema_links(self):
+        """
+        Test access to all schemas
+        """
+        with self.subTest(msg='Fetching Overview'):
+            response = self.client.get('/schema/', follow=False)
+            self.assertEqual(200, response.status_code)
+        with self.subTest(msg='Checking that all published elements are available'):
+            soup = BeautifulSoup(response.content.decode('utf-8'), 'html.parser').find_all('a')
+            self.assertEqual(len(soup), len(PUBLISHED))
+        for link_element in soup:
+            link = link_element['href']
+            with self.subTest(msg='Testing link "{}"'.format(link)):
+                response = self.client.get(link, follow=False)
+                self.assertEqual(200, response.status_code)
+                self.assertEqual('application/schema+json', response.content_type)
+                bad_version_link = link.replace('-v1', '-v99999999')
+                with self.subTest(msg='Testing a bad version for the link: "{}"'.format(bad_version_link)):
+                    response = self.client.get(bad_version_link, follow=False)
+                    self.assertEqual(404, response.status_code)
+
+    def test_non_existing_schema_name(self):
+        """
+        Test a schema that does not exist
+        """
+        response = self.client.get('/schema/not-existing-v1', follow=False)
+        self.assertEqual(404, response.status_code)

--- a/hub_json_schema/urls.py
+++ b/hub_json_schema/urls.py
@@ -1,0 +1,11 @@
+"""
+URL Config for the hub_json_schema, which delivers JSON Schemas
+"""
+from django.conf.urls import url
+
+from hub_json_schema.views import ListJSONSchemasView, JSONSchemaView
+
+urlpatterns = [  # pylint: disable=invalid-name
+    url(r'(?P<schema>[a-z][a-z0-9\-]{0,50}[a-z0-9])-v(?P<version>\d+)$', JSONSchemaView.as_view(), name='schema'),
+    url(r'^$', ListJSONSchemasView.as_view(), name='list'),
+]

--- a/hub_json_schema/views.py
+++ b/hub_json_schema/views.py
@@ -1,0 +1,51 @@
+"""
+Views for the JSON Schema Delivery
+"""
+from django.http import HttpRequest, Http404, JsonResponse
+from django.views import View
+from django.views.generic import TemplateView
+
+from hub_json_schema.registry import Registry
+
+
+class JsonSchemaResponse(JsonResponse):
+    """
+    A JSON schema response
+    """
+
+    content_type = 'application/schema+json'
+
+
+class ListJSONSchemasView(TemplateView):
+    """
+    List available JSON Schemas
+    """
+
+    content_type = 'text/html'
+    template_name = 'hub_json_schema/list-view.html'
+
+    def get_context_data(self, **kwargs):
+        context = super(ListJSONSchemasView, self).get_context_data(**kwargs)
+        context['schemas'] = Registry().schemas
+        return context
+
+
+class JSONSchemaView(View):
+    """
+    Show a JSON Schema
+    """
+
+    http_method_names = ['get']
+
+    def get(self, request: HttpRequest, schema: str, version: str):
+        """
+        Send the schema
+        """
+        registry = Registry()
+        schema = registry.schemas.get(schema, None)
+        if schema is None:
+            raise Http404()
+        version = schema.get(version, None)
+        if version is None:
+            raise Http404()
+        return JsonSchemaResponse(version, json_dumps_params={'indent': 2})


### PR DESCRIPTION
- Page that lists all available schemas
- Starter set of Credential Schemas
- Tests for the Views

Schemas are served by a new app, 'hub_json_schema', with the URL namespace 'json' and fully independent of the main 'hub_app'.